### PR TITLE
Emit loadStart event for scrub previews

### DIFF
--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -9,6 +9,7 @@ import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderU
 import type { NumberType, TypedArray } from "./types.js";
 import { type ImageInfo, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
 import type { VolumeDims } from "./VolumeDims.js";
+import EventDispatcher from "./EventDispatcher.js";
 
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;
@@ -22,7 +23,11 @@ interface VolumeDataObserver {
  * @class
  * @param {ImageInfo} imageInfo
  */
-export default class Volume {
+export default class Volume extends EventDispatcher<{
+  loadStart: undefined;
+  loadComplete: undefined;
+  loadError: { error: unknown };
+}> {
   public imageInfo: CImageInfo;
   public loadSpec: Required<LoadSpec>;
   public loader?: IVolumeLoader;
@@ -73,6 +78,7 @@ export default class Volume {
   private loaded: boolean;
 
   constructor(imageInfo: ImageInfo = defaultImageInfo(), loadSpec: LoadSpec = new LoadSpec(), loader?: IVolumeLoader) {
+    super();
     this.loaded = false;
     this.imageInfo = new CImageInfo(imageInfo);
     // TODO: use getter?
@@ -233,13 +239,16 @@ export default class Volume {
       ...this.loadSpecRequired,
       subregion: this.loadSpecRequired.subregion.clone(),
     };
+    this.dispatchEvent({ type: "loadStart" });
 
     try {
       await this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
     } catch (e) {
+      this.dispatchEvent({ type: "loadError", error: e });
       this.volumeDataObservers.forEach((observer) => observer.onVolumeLoadError(this, e));
       throw e;
     }
+    this.dispatchEvent({ type: "loadComplete" });
   }
 
   // we calculate the physical size of the volume (voxels*pixel_size)

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -25,8 +25,6 @@ interface VolumeDataObserver {
  */
 export default class Volume extends EventDispatcher<{
   loadStart: undefined;
-  loadComplete: undefined;
-  loadError: { error: unknown };
 }> {
   public imageInfo: CImageInfo;
   public loadSpec: Required<LoadSpec>;
@@ -244,11 +242,9 @@ export default class Volume extends EventDispatcher<{
     try {
       await this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
     } catch (e) {
-      this.dispatchEvent({ type: "loadError", error: e });
       this.volumeDataObservers.forEach((observer) => observer.onVolumeLoadError(this, e));
       throw e;
     }
-    this.dispatchEvent({ type: "loadComplete" });
   }
 
   // we calculate the physical size of the volume (voxels*pixel_size)

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -18,14 +18,16 @@ interface VolumeDataObserver {
   onVolumeLoadError: (vol: Volume, error: unknown) => void;
 }
 
+export type VolumeEvent = {
+  loadStart: void;
+};
+
 /**
  * A renderable multichannel volume image with 8-bits per channel intensity values.
  * @class
  * @param {ImageInfo} imageInfo
  */
-export default class Volume extends EventDispatcher<{
-  loadStart: undefined;
-}> {
+export default class Volume extends EventDispatcher<VolumeEvent> {
   public imageInfo: CImageInfo;
   public loadSpec: Required<LoadSpec>;
   public loader?: IVolumeLoader;

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -5,6 +5,7 @@ import VolumeMaker from "../VolumeMaker.js";
 import { LUT_ARRAY_LENGTH } from "../Lut.js";
 import Channel from "../Channel.js";
 import { CImageInfo, ImageInfo } from "../ImageInfo.js";
+import { IVolumeLoader, LoadSpec } from "../loaders/IVolumeLoader.js";
 import { getDataRange } from "../utils/num_utils.js";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
@@ -44,6 +45,30 @@ const testimgdata: ImageInfo = {
     scale: [1, 1, 1],
   },
 };
+
+const multiscaleTestimgdata: ImageInfo = {
+  ...testimgdata,
+  multiscaleLevelDims: [
+    ...testimgdata.multiscaleLevelDims,
+    {
+      shape: [1, 9, 33, 146, 102],
+      spacing: [1, 1, 0.58, (0.065 * 494) / 146, (0.065 * 306) / 102],
+      spaceUnit: "",
+      timeUnit: "",
+      dataType: "uint8",
+    },
+  ],
+};
+
+function createTestLoader(multiscaleLevelDims: ImageInfo["multiscaleLevelDims"]): IVolumeLoader {
+  return {
+    loadDims: vi.fn().mockResolvedValue(multiscaleLevelDims),
+    createVolume: vi.fn(),
+    loadVolumeData: vi.fn(),
+    setPrefetchPriority: vi.fn(),
+    syncMultichannelLoading: vi.fn(),
+  };
+}
 
 function checkVolumeConstruction(v: Volume, imgdata: ImageInfo) {
   expect(v).to.be.a("Object");
@@ -130,9 +155,25 @@ describe("test volume", () => {
   });
 
   describe("loading events", () => {
+    it("dispatches loadStart when changing scale levels", async () => {
+      // ARRANGE
+      const loader = createTestLoader(multiscaleTestimgdata.multiscaleLevelDims);
+      const v = new Volume(multiscaleTestimgdata, new LoadSpec(), loader);
+      const loadStart = vi.fn();
+      v.addEventListener("loadStart", loadStart);
+
+      // ACT: Simulate beginning scrubbing
+      await v.updateRequiredData({ scaleLevelBias: 1 });
+
+      // ASSERT
+      expect(loadStart).toHaveBeenCalled();
+    });
+
     it("does not dispatch loadStart when no reload is required", async () => {
       // ARRANGE
-      const v = new Volume(testimgdata);
+      // loader is needed for loadStart to potentially be triggered
+      const loader = createTestLoader(testimgdata.multiscaleLevelDims);
+      const v = new Volume(testimgdata, new LoadSpec(), loader);
       const loadStart = vi.fn();
       v.addEventListener("loadStart", loadStart);
 

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import Volume from "../Volume.js";
 import VolumeMaker from "../VolumeMaker.js";
@@ -126,6 +126,22 @@ describe("test volume", () => {
       expect(v.normPhysicalSize.x).to.be.closeTo(sx, EPSILON);
       expect(v.normPhysicalSize.y).to.be.closeTo(sy, EPSILON);
       expect(v.normPhysicalSize.z).to.be.closeTo(sz, EPSILON);
+    });
+  });
+
+  describe("loading events", () => {
+    it("does not dispatch loadStart when no reload is required", async () => {
+      // ARRANGE
+      const v = new Volume(testimgdata);
+      const loadStart = vi.fn();
+      v.addEventListener("loadStart", loadStart);
+
+      // ACT: Simulate beginning scrubbing
+      await v.updateRequiredData({ scaleLevelBias: 1 });
+
+      // ASSERT: `testimgdata` has only one multiscale level, so
+      // changing scaleLevelBias should trigger any load.
+      expect(loadStart).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -140,7 +140,7 @@ describe("test volume", () => {
       await v.updateRequiredData({ scaleLevelBias: 1 });
 
       // ASSERT: `testimgdata` has only one multiscale level, so
-      // changing scaleLevelBias should trigger any load.
+      // changing scaleLevelBias should not trigger any load.
       expect(loadStart).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
# Context
My open PRs ([vole-core](https://github.com/allen-cell-animated/vole-core/pull/445), [vole-app](https://github.com/allen-cell-animated/vole-app/pull/555)) for adding low-res previews introduce a bug, and I think the best fix is to use @frasercl's open PR #449. So the base branch for this PR is a merge commit that includes both relevent vole-core changes: I will update this when #449 merges.

# Problem
If the user manually selects a scale level from a ZARR, then scrubs, the loading indicator does not disappear after the scrub finishes (because the same resolution level is used during and after the scrub, no load is triggered when the user releases the scrub).

Currently, vole-app just assumes that data needs to be loaded, and displays the indicator. But vole-app does not have enough information to actually decide if loading is happening.

# Solution

Make vole-core tell vole-app when loading is in progress, by using a `loadStartEvent`.

# Rationale
It would make a lot of sense to also have `loadComplete` and `loadError` events. But they (mainly the `loadComplete` event) bloat this PR and, if implemented naively, add concurrency issues with stale loads. So this PR just adds the simple `loadStart`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to Verify:

With the [companion PR](https://github.com/allen-cell-animated/vole-app/pull/559) in vole-app:
- Load https://allencell.s3.us-east-1.amazonaws.com/aics/emt_timelapse_dataset/data/3500005548_45_raw_converted.ome.zarr/
- Switch to manual scale level selection
- Drag the T slider, and don't release it until the loading spinner goes away.
- Release the slider.
- Verify that there is no loading spinner