### PR TITLE
Low res text

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -1007,11 +1007,11 @@ function setSyncMultichannelLoading(sync: boolean) {
 }
 
 function setLowResPreview(enabled: boolean) {
-  // Known brittleness: this line and OmeZarrLoader.beginLowResPrefetch pick the same level for low-res
-  // pre-fetching and low-res display by selecting the coarsest level, which relies on both
-  // implementations having similar logic.
-  const scaleLevelBias = enabled ? myState.volume.imageInfo.numMultiscaleLevels : 0;
-  void myState.volume.updateRequiredData({ scaleLevelBias }, onChannelDataArrived);
+  if (enabled) {
+    void view3D.enableScrubIndicator(myState.volume);
+  } else {
+    view3D.disableScrubIndicator();
+  }
 }
 
 function playTimeSeries(onNewFrameCallback: () => void) {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -67,6 +67,10 @@ type AnimateFunction = (
   scene: Scene
 ) => void;
 
+function setVisibility(element: HTMLElement, visible: boolean): void {
+  element.style.display = visible ? "" : "none";
+}
+
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;
   private canvas: HTMLCanvasElement;
@@ -113,6 +117,7 @@ export class ThreeJsPanel {
   public showPerspectiveScaleBar: boolean;
   private timestepIndicatorElement: HTMLDivElement;
   public showTimestepIndicator: boolean;
+  private lowResIndicatorElement: HTMLDivElement;
 
   private dataurlcallback?: (url: string) => void;
   private onRenderCallback?: () => void;
@@ -151,6 +156,7 @@ export class ThreeJsPanel {
     this.showPerspectiveScaleBar = false;
     this.timestepIndicatorElement = document.createElement("div");
     this.showTimestepIndicator = false;
+    this.lowResIndicatorElement = document.createElement("div");
 
     this.animateFuncs = [];
     this.postMeshRenderFuncs = [];
@@ -464,6 +470,22 @@ export class ThreeJsPanel {
     };
     Object.assign(this.timestepIndicatorElement.style, timestepIndicatorStyle);
     this.containerdiv.appendChild(this.timestepIndicatorElement);
+
+    // Low-resolution preview indicator
+    const lowResIndicatorStyle: Partial<CSSStyleDeclaration> = {
+      fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      position: "absolute",
+      left: "50%",
+      bottom: "20px",
+      transform: "translateX(-50%)",
+      color: "white",
+      mixBlendMode: "difference",
+      textAlign: "center",
+      display: "none",
+    };
+    Object.assign(this.lowResIndicatorElement.style, lowResIndicatorStyle);
+    this.lowResIndicatorElement.textContent = "Low-resolution preview";
+    this.containerdiv.appendChild(this.lowResIndicatorElement);
   }
 
   updateOrthoScaleBar(scale: number, unit?: string): void {
@@ -499,8 +521,8 @@ export class ThreeJsPanel {
     const isOrtho = isOrthographicCamera(this.camera);
     const orthoVisible = isOrtho && this.showOrthoScaleBar;
     const perspectiveVisible = !isOrtho && this.showPerspectiveScaleBar;
-    this.orthoScaleBarElement.style.display = orthoVisible ? "" : "none";
-    this.perspectiveScaleBarElement.style.display = perspectiveVisible ? "" : "none";
+    setVisibility(this.orthoScaleBarElement, orthoVisible);
+    setVisibility(this.perspectiveScaleBarElement, perspectiveVisible);
   }
 
   setShowOrthoScaleBar(visible: boolean): void {
@@ -515,7 +537,11 @@ export class ThreeJsPanel {
 
   setShowTimestepIndicator(visible: boolean): void {
     this.showTimestepIndicator = visible;
-    this.timestepIndicatorElement.style.display = visible ? "" : "none";
+    setVisibility(this.timestepIndicatorElement, visible);
+  }
+
+  setShowLowResIndicator(visible: boolean): void {
+    this.lowResIndicatorElement.style.display = visible ? "" : "none";
   }
 
   setIndicatorPosition(timestep: boolean, marginX: number, marginY: number, corner: ViewportCorner) {
@@ -533,6 +559,13 @@ export class ThreeJsPanel {
       [xProp]: marginX + "px",
       [yProp]: marginY + "px",
     });
+  }
+
+  setLowResIndicatorPosition(marginY: number, fromTop: boolean): void {
+    const { style: centerStyle } = this.lowResIndicatorElement;
+    centerStyle.removeProperty("top");
+    centerStyle.removeProperty("bottom");
+    centerStyle[fromTop ? "top" : "bottom"] = marginY + "px";
   }
 
   setAutoRotate(rotate: boolean): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -70,6 +70,10 @@ type AnimateFunction = (
   scene: Scene
 ) => void;
 
+function setVisibility(element: HTMLElement, visible: boolean): void {
+  element.style.display = visible ? "" : "none";
+}
+
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;
   private canvas: HTMLCanvasElement;
@@ -117,6 +121,7 @@ export class ThreeJsPanel {
   public showPerspectiveScaleBar: boolean;
   private timestepIndicatorElement: HTMLDivElement;
   public showTimestepIndicator: boolean;
+  private lowResIndicatorElement: HTMLDivElement;
 
   private dataurlcallback?: (url: string) => void;
   private onRenderCallback?: () => void;
@@ -157,6 +162,7 @@ export class ThreeJsPanel {
     this.showPerspectiveScaleBar = false;
     this.timestepIndicatorElement = document.createElement("div");
     this.showTimestepIndicator = false;
+    this.lowResIndicatorElement = document.createElement("div");
 
     this.animateFuncs = [];
     this.postMeshRenderFuncs = [];
@@ -491,6 +497,22 @@ export class ThreeJsPanel {
     };
     Object.assign(this.timestepIndicatorElement.style, timestepIndicatorStyle);
     this.containerdiv.appendChild(this.timestepIndicatorElement);
+
+    // Low-resolution preview indicator
+    const lowResIndicatorStyle: Partial<CSSStyleDeclaration> = {
+      fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      position: "absolute",
+      left: "50%",
+      bottom: "20px",
+      transform: "translateX(-50%)",
+      color: "white",
+      mixBlendMode: "difference",
+      textAlign: "center",
+      display: "none",
+    };
+    Object.assign(this.lowResIndicatorElement.style, lowResIndicatorStyle);
+    this.lowResIndicatorElement.textContent = "Low-resolution preview";
+    this.containerdiv.appendChild(this.lowResIndicatorElement);
   }
 
   updateOrthoScaleBar(scale: number, unit?: string): void {
@@ -526,8 +548,8 @@ export class ThreeJsPanel {
     const isOrtho = isOrthographicCamera(this.camera);
     const orthoVisible = isOrtho && this.showOrthoScaleBar;
     const perspectiveVisible = !isOrtho && this.showPerspectiveScaleBar;
-    this.orthoScaleBarElement.style.display = orthoVisible ? "" : "none";
-    this.perspectiveScaleBarElement.style.display = perspectiveVisible ? "" : "none";
+    setVisibility(this.orthoScaleBarElement, orthoVisible);
+    setVisibility(this.perspectiveScaleBarElement, perspectiveVisible);
   }
 
   setShowOrthoScaleBar(visible: boolean): void {
@@ -542,7 +564,11 @@ export class ThreeJsPanel {
 
   setShowTimestepIndicator(visible: boolean): void {
     this.showTimestepIndicator = visible;
-    this.timestepIndicatorElement.style.display = visible ? "" : "none";
+    setVisibility(this.timestepIndicatorElement, visible);
+  }
+
+  setShowLowResIndicator(visible: boolean): void {
+    this.lowResIndicatorElement.style.display = visible ? "" : "none";
   }
 
   setIndicatorPosition(timestep: boolean, marginX: number, marginY: number, corner: ViewportCorner) {
@@ -560,6 +586,13 @@ export class ThreeJsPanel {
       [xProp]: marginX + "px",
       [yProp]: marginY + "px",
     });
+  }
+
+  setLowResIndicatorPosition(marginY: number, fromTop: boolean): void {
+    const { style: centerStyle } = this.lowResIndicatorElement;
+    centerStyle.removeProperty("top");
+    centerStyle.removeProperty("bottom");
+    centerStyle[fromTop ? "top" : "bottom"] = marginY + "px";
   }
 
   setAutoRotate(rotate: boolean): void {

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -300,6 +300,15 @@ export class View3d extends EventDispatcher<{
     volume.updateRequiredData({ scaleLevelBias });
   }
 
+  async enableScrubIndicator(volume: Volume): Promise<void> {
+    const selectsDifferentLevel = await volume.biasesSelectDifferentLevels();
+    this.canvas3d.setShowLowResIndicator(selectsDifferentLevel);
+  }
+
+  disableScrubIndicator(): void {
+    this.canvas3d.setShowLowResIndicator(false);
+  }
+
   /**
    * Assign a channel index as a mask channel (will multiply its color against the entire visible volume)
    * @param {Object} volume
@@ -602,6 +611,15 @@ export class View3d extends EventDispatcher<{
    */
   setTimestepIndicatorPosition(marginX: number, marginY: number, corner = ViewportCorner.BOTTOM_RIGHT): void {
     this.canvas3d.setIndicatorPosition(true, marginX, marginY, corner);
+  }
+
+  /**
+   * Set the vertical position of the horizontally centered low-resolution indicator.
+   * @param {number} marginY
+   * @param {boolean} [fromTop] Whether the margin is measured from the top. Default: `false`.
+   */
+  setLowResIndicatorPosition(marginY: number, fromTop = false): void {
+    this.canvas3d.setLowResIndicatorPosition(marginY, fromTop);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -343,6 +343,15 @@ export class View3d extends EventDispatcher<View3dEvents> {
     volume.updateRequiredData({ scaleLevelBias });
   }
 
+  async enableScrubIndicator(volume: Volume): Promise<void> {
+    const selectsDifferentLevel = await volume.biasesSelectDifferentLevels();
+    this.canvas3d.setShowLowResIndicator(selectsDifferentLevel);
+  }
+
+  disableScrubIndicator(): void {
+    this.canvas3d.setShowLowResIndicator(false);
+  }
+
   /**
    * Assign a channel index as a mask channel (will multiply its color against the entire visible volume)
    * @param {Object} volume
@@ -700,6 +709,15 @@ export class View3d extends EventDispatcher<View3dEvents> {
    */
   setTimestepIndicatorPosition(marginX: number, marginY: number, corner = ViewportCorner.BOTTOM_RIGHT): void {
     this.canvas3d.setIndicatorPosition(true, marginX, marginY, corner);
+  }
+
+  /**
+   * Set the vertical position of the horizontally centered low-resolution indicator.
+   * @param {number} marginY
+   * @param {boolean} [fromTop] Whether the margin is measured from the top. Default: `false`.
+   */
+  setLowResIndicatorPosition(marginY: number, fromTop = false): void {
+    this.canvas3d.setLowResIndicatorPosition(marginY, fromTop);
   }
 
   /**

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -196,6 +196,12 @@ export default class Volume extends EventDispatcher<{
     );
   }
 
+  async getDimsZYX(): Promise<[number, number, number][] | undefined> {
+    // Loaders should cache loaded dimensions so that this call blocks no more than once per valid `LoadSpec`.
+    const dims = await this.loadScaleLevelDims();
+    return dims?.map(({ shape }): [number, number, number] => [shape[2], shape[3], shape[4]]);
+  }
+
   /** Call on any state update that may require new data to be loaded (subregion, enabled channels, time, etc.) */
   async updateRequiredData(required: Partial<LoadSpec>, onChannelLoaded?: PerChannelCallback): Promise<void> {
     this.loadSpecRequired = { ...this.loadSpecRequired, ...required };
@@ -203,10 +209,8 @@ export default class Volume extends EventDispatcher<{
 
     // If we're not reloading due to required data changes, check if we should load a new scale level
     if (!shouldReload && this.mayLoadNewScaleLevel()) {
-      // Loaders should cache loaded dimensions so that this call blocks no more than once per valid `LoadSpec`.
-      const dims = await this.loadScaleLevelDims();
-      if (dims) {
-        const dimsZYX = dims.map(({ shape }): [number, number, number] => [shape[2], shape[3], shape[4]]);
+      const dimsZYX = await this.getDimsZYX();
+      if (dimsZYX) {
         // Determine which scale level *would* be loaded, and see if it's different than what we have
         const levelToLoad = pickLevelToLoadUnscaled(this.loadSpecRequired, dimsZYX);
         shouldReload = this.imageInfo.multiscaleLevel !== levelToLoad;
@@ -216,6 +220,18 @@ export default class Volume extends EventDispatcher<{
     if (shouldReload) {
       await this.loadNewData(onChannelLoaded);
     }
+  }
+
+  /**
+   * Returns whether two scale-level biases would select different resolution levels.
+   * Returns false if dimensions cannot be loaded.
+   */
+  async biasesSelectDifferentLevels(): Promise<boolean> {
+    const dimsZYX = await this.getDimsZYX();
+    if (!dimsZYX) return false;
+    const unbiased = pickLevelToLoadUnscaled({ ...this.loadSpecRequired, scaleLevelBias: 0}, dimsZYX);
+    const withBias = pickLevelToLoadUnscaled(this.loadSpecRequired, dimsZYX);
+    return unbiased !== withBias;
   }
 
   private async loadScaleLevelDims(): Promise<VolumeDims[] | undefined> {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -198,6 +198,12 @@ export default class Volume extends EventDispatcher<VolumeEvent> {
     );
   }
 
+  async getDimsZYX(): Promise<[number, number, number][] | undefined> {
+    // Loaders should cache loaded dimensions so that this call blocks no more than once per valid `LoadSpec`.
+    const dims = await this.loadScaleLevelDims();
+    return dims?.map(({ shape }): [number, number, number] => [shape[2], shape[3], shape[4]]);
+  }
+
   /** Call on any state update that may require new data to be loaded (subregion, enabled channels, time, etc.) */
   async updateRequiredData(required: Partial<LoadSpec>, onChannelLoaded?: PerChannelCallback): Promise<void> {
     this.loadSpecRequired = { ...this.loadSpecRequired, ...required };
@@ -205,10 +211,8 @@ export default class Volume extends EventDispatcher<VolumeEvent> {
 
     // If we're not reloading due to required data changes, check if we should load a new scale level
     if (!shouldReload && this.mayLoadNewScaleLevel()) {
-      // Loaders should cache loaded dimensions so that this call blocks no more than once per valid `LoadSpec`.
-      const dims = await this.loadScaleLevelDims();
-      if (dims) {
-        const dimsZYX = dims.map(({ shape }): [number, number, number] => [shape[2], shape[3], shape[4]]);
+      const dimsZYX = await this.getDimsZYX();
+      if (dimsZYX) {
         // Determine which scale level *would* be loaded, and see if it's different than what we have
         const levelToLoad = pickLevelToLoadUnscaled(this.loadSpecRequired, dimsZYX);
         shouldReload = this.imageInfo.multiscaleLevel !== levelToLoad;
@@ -218,6 +222,18 @@ export default class Volume extends EventDispatcher<VolumeEvent> {
     if (shouldReload) {
       await this.loadNewData(onChannelLoaded);
     }
+  }
+
+  /**
+   * Returns whether two scale-level biases would select different resolution levels.
+   * Returns false if dimensions cannot be loaded.
+   */
+  async biasesSelectDifferentLevels(): Promise<boolean> {
+    const dimsZYX = await this.getDimsZYX();
+    if (!dimsZYX) return false;
+    const unbiased = pickLevelToLoadUnscaled({ ...this.loadSpecRequired, scaleLevelBias: 0}, dimsZYX);
+    const withBias = pickLevelToLoadUnscaled(this.loadSpecRequired, dimsZYX);
+    return unbiased !== withBias;
   }
 
   private async loadScaleLevelDims(): Promise<VolumeDims[] | undefined> {

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -185,4 +185,26 @@ describe("test volume", () => {
       expect(loadStart).not.toHaveBeenCalled();
     });
   });
+
+  describe("biasesSelectDifferentLevels", () => {
+    it("reports when the scale-level bias selects a different resolution", async () => {
+      // ARRANGE
+      const loader = createTestLoader(multiscaleTestimgdata.multiscaleLevelDims);
+      const loadSpec = new LoadSpec();
+      loadSpec.scaleLevelBias = 1;
+      const v = new Volume(multiscaleTestimgdata, loadSpec, loader);
+
+      // ACT+ASSERT
+      expect(await v.biasesSelectDifferentLevels()).toBe(true);
+    });
+
+    it("reports when the scale-level bias selects the same resolution", async () => {
+      // ARRANGE
+      const loader = createTestLoader(multiscaleTestimgdata.multiscaleLevelDims);
+      const v = new Volume(multiscaleTestimgdata, new LoadSpec(), loader);
+
+      // ACT+ASSERT
+      expect(await v.biasesSelectDifferentLevels()).toBe(false);
+    });
+  });
 });

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -5,6 +5,7 @@ import VolumeMaker from "../VolumeMaker.js";
 import { LUT_ARRAY_LENGTH } from "../Lut.js";
 import Channel from "../Channel.js";
 import { CImageInfo, ImageInfo } from "../ImageInfo.js";
+import { IVolumeLoader, LoadSpec } from "../loaders/IVolumeLoader.js";
 import { getDataRange } from "../utils/num_utils.js";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
@@ -44,6 +45,30 @@ const testimgdata: ImageInfo = {
     scale: [1, 1, 1],
   },
 };
+
+const multiscaleTestimgdata: ImageInfo = {
+  ...testimgdata,
+  multiscaleLevelDims: [
+    ...testimgdata.multiscaleLevelDims,
+    {
+      shape: [1, 9, 33, 146, 102],
+      spacing: [1, 1, 0.58, (0.065 * 494) / 146, (0.065 * 306) / 102],
+      spaceUnit: "",
+      timeUnit: "",
+      dataType: "uint8",
+    },
+  ],
+};
+
+function createTestLoader(multiscaleLevelDims: ImageInfo["multiscaleLevelDims"]): IVolumeLoader {
+  return {
+    loadDims: vi.fn().mockResolvedValue(multiscaleLevelDims),
+    createVolume: vi.fn(),
+    loadVolumeData: vi.fn(),
+    setPrefetchPriority: vi.fn(),
+    syncMultichannelLoading: vi.fn(),
+  };
+}
 
 function checkVolumeConstruction(v: Volume, imgdata: ImageInfo) {
   expect(v).to.be.a("Object");
@@ -132,7 +157,9 @@ describe("test volume", () => {
   describe("loading events", () => {
     it("does not dispatch loadStart when no reload is required", async () => {
       // ARRANGE
-      const v = new Volume(testimgdata);
+      // loader is needed for loadStart to potentially be triggered
+      const loader = createTestLoader(testimgdata.multiscaleLevelDims);
+      const v = new Volume(testimgdata, new LoadSpec(), loader);
       const loadStart = vi.fn();
       v.addEventListener("loadStart", loadStart);
 
@@ -142,6 +169,28 @@ describe("test volume", () => {
       // ASSERT: `testimgdata` has only one multiscale level, so
       // changing scaleLevelBias should not trigger any load.
       expect(loadStart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("biasesSelectDifferentLevels", () => {
+    it("reports when the scale-level bias selects a different resolution", async () => {
+      // ARRANGE
+      const loader = createTestLoader(multiscaleTestimgdata.multiscaleLevelDims);
+      const loadSpec = new LoadSpec();
+      loadSpec.scaleLevelBias = 1;
+      const v = new Volume(multiscaleTestimgdata, loadSpec, loader);
+
+      // ACT+ASSERT
+      expect(await v.biasesSelectDifferentLevels()).toBe(true);
+    });
+
+    it("reports when the scale-level bias selects the same resolution", async () => {
+      // ARRANGE
+      const loader = createTestLoader(multiscaleTestimgdata.multiscaleLevelDims);
+      const v = new Volume(multiscaleTestimgdata, new LoadSpec(), loader);
+
+      // ACT+ASSERT
+      expect(await v.biasesSelectDifferentLevels()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Problem

The UX design for the low-res previews while scrubbing includes the text "Low-resolution preview" at the bottom center of the display.

With the vole-app [companion PR](https://github.com/allen-cell-animated/vole-app/pull/561), this resolves https://github.com/allen-cell-animated/vole-app/issues/523

# Solution

Add a new text element. vole-app is responsible for identifying when scrubbing is happening. vole-core is responsible for identifying when the scale level displayed is lower-resolution than what would be displayed if the user weren't scrubbing.

# Limitations
On smaller screens, the "Low-resolution preview" text can overlap the scale bar. If this is an issue, there are two main routes forward:
- Remove the vole-core APIs for putting the indicators in arbitrary corners, and always assume the low-res indicator is bottom-center while the scale bar and timestep are bottom-right
- Move the low-res preview text to the bottom right

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to Verify:

- Load this test file: https://allencell.s3.us-east-1.amazonaws.com/aics/emt_timelapse_dataset/data/3500005548_45_raw_converted.ome.zarr/
- Scrub: indicator is displayed
- Switch to manual mode, and scrub: no indicator

## Screenshots

https://github.com/user-attachments/assets/bde4896c-54ff-4fe1-9e32-1ba99d3e7a71