### PR TITLE
Abort requests with no subscribers

### DIFF
--- a/src/loaders/zarr_utils/wrappers.ts
+++ b/src/loaders/zarr_utils/wrappers.ts
@@ -49,7 +49,7 @@ export const withVoleInstrumentation = defineArrayExtension((array, opts: VoleIn
       const abort = () => controller.abort();
       const result =
         opts.queue && opts.subscriber !== undefined
-          ? await opts.queue.addRequest(fullKey, opts.subscriber, fetchChunk, abort, opts.isPrefetch)
+          ? await opts.queue.addRequest(fullKey, opts.subscriber, fetchChunk, opts.isPrefetch, undefined, abort)
           : await fetchChunk();
 
       opts.cache?.insert(fullKey, result);

--- a/src/loaders/zarr_utils/wrappers.ts
+++ b/src/loaders/zarr_utils/wrappers.ts
@@ -42,10 +42,14 @@ export const withVoleInstrumentation = defineArrayExtension((array, opts: VoleIn
         return cached;
       }
 
-      const fetchChunk = () => array.getChunk(coords, options, inner);
+      const controller = new AbortController();
+      // Abort the chunk if either abort signal is triggered
+      const signal = AbortSignal.any([options?.signal, controller.signal].filter(s => s !== undefined));
+      const fetchChunk = () => array.getChunk(coords, { ...options, signal }, inner);
+      const abort = () => controller.abort();
       const result =
         opts.queue && opts.subscriber !== undefined
-          ? await opts.queue.addRequest(fullKey, opts.subscriber, fetchChunk, opts.isPrefetch)
+          ? await opts.queue.addRequest(fullKey, opts.subscriber, fetchChunk, abort, opts.isPrefetch)
           : await fetchChunk();
 
       opts.cache?.insert(fullKey, result);

--- a/src/loaders/zarr_utils/wrappers.ts
+++ b/src/loaders/zarr_utils/wrappers.ts
@@ -46,7 +46,7 @@ export const withVoleInstrumentation = defineArrayExtension((array, opts: VoleIn
       // Abort the chunk if either abort signal is triggered
       const signal = AbortSignal.any([options?.signal, controller.signal].filter(s => s !== undefined));
       const fetchChunk = () => array.getChunk(coords, { ...options, signal }, inner);
-      const abort = () => controller.abort();
+      const abort = controller.abort.bind(controller);
       const result =
         opts.queue && opts.subscriber !== undefined
           ? await opts.queue.addRequest(fullKey, opts.subscriber, fetchChunk, opts.isPrefetch, undefined, abort)

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -192,26 +192,33 @@ describe("SubscribableRequestQueue", () => {
       expect(queue.cancelRequest("test", id)).to.be.false;
     });
 
-    it("does not cancel an underlying request if it is running", async () => {
+    it("aborts a request even it is running", async () => {
+      // Arrange
       const queue = new SubscribableRequestQueue();
       const id1 = queue.addSubscriber();
       const id2 = queue.addSubscriber();
+      const abort = vi.fn();
 
-      const promise1 = queue.addRequest("test", id1, () => delay(TIMEOUT, "foo"));
+      const promise1 = queue.addRequest("test", id1, () => delay(TIMEOUT, "foo"), undefined, undefined, abort);
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.requestRunning("test")).to.be.true;
       expect(queue.isSubscribed(id1, "test")).to.be.true;
       expect(queue.isSubscribed(id2, "test")).to.be.false;
 
+      // Act
       queue.cancelRequest("test", id1);
-      expect(queue.hasRequest("test")).to.be.true;
+      // Assert
+      expect(queue.hasRequest("test")).to.be.false;
       expect(queue.isSubscribed(id1, "test")).to.be.false;
       expect(await isRejected(promise1)).to.be.true;
+      expect(abort).toHaveBeenCalled();
 
+      // Act
       const promise2 = queue.addRequest("test", id2, () => delay(TIMEOUT, "bar"));
+      // Assert
       expect(queue.isSubscribed(id2, "test")).to.be.true;
       const result = await promise2;
-      expect(result).to.equal("foo");
+      expect(result).to.equal("bar");
     });
 
     it("does not cancel an underlying request if it has another subscription", async () => {

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -263,6 +263,52 @@ describe("SubscribableRequestQueue", () => {
       expect(queue.hasRequest("test")).to.be.false;
       expect(queue.isSubscribed(id, "test")).to.be.false;
     });
+
+    it("keeps a reissued request tracked when another request is canceled", async () => {
+      // Arrange
+      const queue = new SubscribableRequestQueue();
+      const firstSubscriber = queue.addSubscriber();
+      const controller = new AbortController();
+
+      queue
+        .addRequest(
+          "same-key",
+          firstSubscriber,
+          () =>
+            new Promise<void>((_, reject) => {
+              // Note: in practice, it's possible that a real fetch would take some
+              // time between receiving the abort signal and rejecting the promise.
+              controller.signal.addEventListener("abort", reject);
+            }),
+          undefined,
+          undefined,
+          () => controller.abort()
+        )
+        .catch(() => undefined);
+
+      // Act
+      queue.removeSubscriber(firstSubscriber); // Triggers abort()
+
+      let resolveSecond: () => void = () => undefined;
+      const second = queue.addRequest(
+        "same-key",
+        queue.addSubscriber(),
+        () => new Promise<void>((resolve) => (resolveSecond = resolve))
+      );
+      const handledSecond = second.catch(() => undefined);
+
+      await delay(0, undefined); // Wait for the abort signal to trigger reject()
+
+      try {
+        // Assert
+        expect(queue.hasRequest("same-key")).to.be.true;
+        expect(queue.requestRunning("same-key")).to.be.true;
+      } finally {
+        // Cleanup
+        resolveSecond();
+        await handledSecond;
+      }
+    });
   });
 
   describe("removeSubscriber", () => {

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -192,7 +192,7 @@ describe("SubscribableRequestQueue", () => {
       expect(queue.cancelRequest("test", id)).to.be.false;
     });
 
-    it("aborts a request even it is running", async () => {
+    it("aborts a request even if it is running", async () => {
       // Arrange
       const queue = new SubscribableRequestQueue();
       const id1 = queue.addSubscriber();

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -234,8 +234,11 @@ export default class RequestQueue {
     this.activeRequests.add(key);
 
     await requestItem.action().then(requestItem.resolve, requestItem.reject);
-    this.activeRequests.delete(key);
-    this.allRequests.delete(key);
+    // A new request for the same key may have been added during the await
+    if (requestItem === this.allRequests.get(requestKey)) {
+      this.activeRequests.delete(key);
+      this.allRequests.delete(key);
+    }
     this.dequeue();
   }
 

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -2,7 +2,7 @@
 export type Request<V> = {
   key: string;
   requestAction: () => Promise<V>;
-  abort: () => void;
+  abort?: () => void;
 };
 
 export const DEFAULT_REQUEST_CANCEL_REASON = "request cancelled";
@@ -15,8 +15,6 @@ interface RequestItem<V> {
   key: string;
   /** Action to be run. */
   action: () => Promise<V>;
-  /** Callback to cancelation the action after it's started */
-  abort: () => void;
   /** Reference to the promise object that will be resolved when the action is complete. */
   promise: Promise<V>;
   /** Callback used to resolve the promise. */
@@ -25,6 +23,8 @@ interface RequestItem<V> {
   reject: (reason?: unknown) => void;
   /** Optional, used to track timeouts if the item will be added to the queue later. */
   timeoutId?: ReturnType<typeof setTimeout>;
+  /** Callback to cancelation the action after it's started */
+  abort?: () => void;
 }
 
 /**
@@ -79,7 +79,7 @@ export default class RequestQueue {
    * @param requestAction callable function action of the request.
    * @returns a reference to the new, registered RequestItem.
    */
-  private registerRequest<T>(key: string, requestAction: () => Promise<T>, abortAction: () => void): RequestItem<T> {
+  private registerRequest<T>(key: string, requestAction: () => Promise<T>, abortAction?: () => void): RequestItem<T> {
     // Create a new promise and store the resolve and reject callbacks for later.
     // This lets us perform the actual action at a later point, when the request is at the
     // front of the processing queue.
@@ -145,7 +145,7 @@ export default class RequestQueue {
    *  until the request is resolved or cancelled.
    *  Note that the return type of the promise will match that of the first request's instance.
    */
-  public addRequest<T>(key: string, requestAction: () => Promise<T>, abortAction: () => void, lowPriority = false, delayMs = 0): Promise<T> {
+  public addRequest<T>(key: string, requestAction: () => Promise<T>, lowPriority = false, delayMs = 0, abortAction?: () => void): Promise<T> {
     if (!this.allRequests.has(key)) {
       // New request!
       const requestItem = this.registerRequest(key, requestAction, abortAction);
@@ -194,7 +194,7 @@ export default class RequestQueue {
     const promises: Promise<unknown>[] = [];
     for (let i = 0; i < requests.length; i++) {
       const item = requests[i];
-      const promise = this.addRequest(item.key, item.requestAction, item.abort, lowPriority, delayMs * i);
+      const promise = this.addRequest(item.key, item.requestAction, lowPriority, delayMs * i, item.abort);
       promises.push(promise);
     }
     return promises;
@@ -255,7 +255,7 @@ export default class RequestQueue {
         clearTimeout(requestItem.timeoutId);
       }
       // Cancel in-progress work
-      requestItem.abort();
+      requestItem.abort?.();
       // Reject the request, then clear from the queue and known requests.
       requestItem.reject(cancelReason);
     }

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -2,6 +2,7 @@
 export type Request<V> = {
   key: string;
   requestAction: () => Promise<V>;
+  abort: () => void;
 };
 
 export const DEFAULT_REQUEST_CANCEL_REASON = "request cancelled";
@@ -14,6 +15,8 @@ interface RequestItem<V> {
   key: string;
   /** Action to be run. */
   action: () => Promise<V>;
+  /** Callback to cancelation the action after it's started */
+  abort: () => void;
   /** Reference to the promise object that will be resolved when the action is complete. */
   promise: Promise<V>;
   /** Callback used to resolve the promise. */
@@ -76,7 +79,7 @@ export default class RequestQueue {
    * @param requestAction callable function action of the request.
    * @returns a reference to the new, registered RequestItem.
    */
-  private registerRequest<T>(key: string, requestAction: () => Promise<T>): RequestItem<T> {
+  private registerRequest<T>(key: string, requestAction: () => Promise<T>, abortAction: () => void): RequestItem<T> {
     // Create a new promise and store the resolve and reject callbacks for later.
     // This lets us perform the actual action at a later point, when the request is at the
     // front of the processing queue.
@@ -89,6 +92,7 @@ export default class RequestQueue {
     const requestItem = {
       key: key,
       action: requestAction,
+      abort: abortAction,
       resolve: promiseResolve,
       reject: promiseReject,
       promise,
@@ -141,10 +145,10 @@ export default class RequestQueue {
    *  until the request is resolved or cancelled.
    *  Note that the return type of the promise will match that of the first request's instance.
    */
-  public addRequest<T>(key: string, requestAction: () => Promise<T>, lowPriority = false, delayMs = 0): Promise<T> {
+  public addRequest<T>(key: string, requestAction: () => Promise<T>, abortAction: () => void, lowPriority = false, delayMs = 0): Promise<T> {
     if (!this.allRequests.has(key)) {
       // New request!
-      const requestItem = this.registerRequest(key, requestAction);
+      const requestItem = this.registerRequest(key, requestAction, abortAction);
       // If a delay is set, wait to add this to the queue.
       if (delayMs > 0) {
         const timeoutId = setTimeout(() => this.addRequestToQueue(key, lowPriority), delayMs);
@@ -190,7 +194,7 @@ export default class RequestQueue {
     const promises: Promise<unknown>[] = [];
     for (let i = 0; i < requests.length; i++) {
       const item = requests[i];
-      const promise = this.addRequest(item.key, item.requestAction, lowPriority, delayMs * i);
+      const promise = this.addRequest(item.key, item.requestAction, item.abort, lowPriority, delayMs * i);
       promises.push(promise);
     }
     return promises;
@@ -250,6 +254,8 @@ export default class RequestQueue {
         // Cancel requests that have not been queued yet.
         clearTimeout(requestItem.timeoutId);
       }
+      // Cancel in-progress work
+      requestItem.abort();
       // Reject the request, then clear from the queue and known requests.
       requestItem.reject(cancelReason);
     }

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -23,7 +23,7 @@ interface RequestItem<V> {
   reject: (reason?: unknown) => void;
   /** Optional, used to track timeouts if the item will be added to the queue later. */
   timeoutId?: ReturnType<typeof setTimeout>;
-  /** Callback to cancelation the action after it's started */
+  /** Callback to cancel the action after it's started */
   abort?: () => void;
 }
 

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -85,12 +85,13 @@ export default class SubscribableRequestQueue {
     key: string,
     subscriberId: number,
     requestAction: () => Promise<T>,
+    abortAction: () => void,
     lowPriority?: boolean,
     delayMs?: number
   ): Promise<T> {
     // Create single underlying request if it does not yet exist
     this.queue
-      .addRequest(key, requestAction, lowPriority, delayMs)
+      .addRequest(key, requestAction, abortAction, lowPriority, delayMs)
       .then((value) => this.resolveAll(key, value))
       .catch((reason) => this.rejectAll(key, reason));
 
@@ -122,7 +123,7 @@ export default class SubscribableRequestQueue {
 
   /**
    * Rejects a subscription and removes it from the list of subscriptions for a request, then cancels the underlying
-   * request if it is no longer subscribed and is not running already.
+   * request if it is no longer subscribed.
    */
   private rejectSubscription(key: string, reject: Rejecter, cancelReason?: unknown): void {
     // Reject the outer "subscription" promise
@@ -140,8 +141,8 @@ export default class SubscribableRequestQueue {
       subscriptions.splice(idx, 1);
     }
 
-    // Remove the underlying request if there are no more subscribers and the request is not already running
-    if (subscriptions.length < 1 && !this.queue.requestRunning(key)) {
+    // Remove the underlying request if there are no more subscribers.
+    if (subscriptions.length < 1) {
       this.queue.cancelRequest(key, cancelReason);
       this.requests.delete(key);
     }

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -85,13 +85,13 @@ export default class SubscribableRequestQueue {
     key: string,
     subscriberId: number,
     requestAction: () => Promise<T>,
-    abortAction: () => void,
     lowPriority?: boolean,
-    delayMs?: number
+    delayMs?: number,
+    abortAction?: () => void,
   ): Promise<T> {
     // Create single underlying request if it does not yet exist
     this.queue
-      .addRequest(key, requestAction, abortAction, lowPriority, delayMs)
+      .addRequest(key, requestAction, lowPriority, delayMs, abortAction)
       .then((value) => this.resolveAll(key, value))
       .catch((reason) => this.rejectAll(key, reason));
 


### PR DESCRIPTION
# Problem

Vol-E helpfully prefetches chunks in the background based on the current view (e.g., nearby timepoints). User interaction may make pre-fetch chunks irrelevant. Currently, Vol-E allows in-flight HTTP requests for such irrelevant chunks to complete, consuming valuable I/O resources and slowing the user experience.

For example:
* With T set to 10, the user clicks "Play" on the Z axis
* Vol-E starts pre-fetching ahead along the Z axis
* User changes T to 11
* In-flight HTTP requests for T=10 continue
* HTTP requests for T=11 begin as the T=10 requests complete.

If instead Vol-E aborts the in-flight requests, the T=11 requests could begin immediately after the user changes T to 11.

Resolves #454 

# Solution
The request queue now stories an optional `abort` function along with each request action, which is called when the last subscriber for the request is removed.

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to Verify:

1. Load a sufficiently large ZARR, like https://allencell.s3.us-east-1.amazonaws.com/aics/emt_timelapse_dataset/data/3500005548_45_raw_converted.ome.zarr/
2. Open the network tab
3. Start playback in T
4. Drag the T slider behind or ahead.
5. Observe the in-flight pre-fetch network requests get the status NS_BINDING_ABORTED:
<img width="507" height="190" alt="Screenshot 2026-08-14 at 4 35 01 PM" src="https://github.com/user-attachments/assets/a04dca4a-f0c8-4dd2-b14b-5bb86b13e7c5" />

## Summary of changes

1. The `abort` function is created in `wrappers.ts`
2. The `abort` function is called in [RequestQueue.ts](https://github.com/allen-cell-animated/vole-core/compare/feature/abort-signal?expand=1#diff-4687fd0e4d58d6309c20aa89002534124f5a19c18ecee8000de3ffec5b2c299aR261)
3. Most of the changes are just threading the `abort` function through between those two.
