### PR TITLE
Prevent tweakpane creation from crashing

### DIFF
--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -938,10 +938,13 @@ export default class VolumeDrawable {
     scaleFolder
       .addInput(this.volume.loadSpecRequired, "scaleLevelBias")
       .on("change", ({ value }) => this.volume.updateRequiredData({ scaleLevelBias: value }));
-    // which level to load
-    scaleFolder
-      .addInput(this.volume.loadSpecRequired, "multiscaleLevel")
-      .on("change", ({ value }) => this.volume.updateRequiredData({ multiscaleLevel: value }));
+    // which level to load - only included if multiscaleLevel is a number
+    // (tweakpane can't handle undefined)
+    if (this.volume.loadSpecRequired.multiscaleLevel !== undefined) {
+      scaleFolder
+        .addInput(this.volume.loadSpecRequired, "multiscaleLevel")
+        .on("change", ({ value }) => this.volume.updateRequiredData({ multiscaleLevel: value }));
+    }
 
     const pathtrace = pane.addFolder({ title: "Pathtrace", expanded: false });
     pathtrace

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -940,7 +940,7 @@ export default class VolumeDrawable {
       .on("change", ({ value }) => this.volume.updateRequiredData({ scaleLevelBias: value }));
     // which level to load - only included if multiscaleLevel is a number
     // (tweakpane can't handle undefined)
-    if (this.volume.loadSpecRequired.multiscaleLevel !== undefined) {
+    if (typeof this.volume.loadSpecRequired.multiscaleLevel === "number") {
       scaleFolder
         .addInput(this.volume.loadSpecRequired, "multiscaleLevel")
         .on("change", ({ value }) => this.volume.updateRequiredData({ multiscaleLevel: value }));


### PR DESCRIPTION
# Problem

If `loadSpecRequired.multiscaleLevel` is undefined, tweakpane throws an error when trying to add a UI element for `multiscaleLevel`, because it expects a strictly numeric input. This causes vole-app to have a partially-generated tweakpane, without the Pathtrace and Prefetch settings (since those come after the line that errors).

But `vole-app` intentionally uses `undefined` as the value for `multiscaleLevel` when auto mode is on.

Resolves #456

# Solution

Don't add a UI element for `multiscaleLevel` if it is undefined.
- In the vole-core demo app, the tweakpane allows adjustment of `multiscaleLevel`.
- In vole-app, the tweakpane only shows `multiscaleLevel` if the user puts vole-app in manual mode before opening the tweakpane (not ideal, but better than before).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to Verify:

1. Open vole-app with an image
2. Press Ctrl+Alt+1
3. The tweakpane opens, no error is logged to the console, and the Pathtrace and Prefetch sections are included
